### PR TITLE
Accept HTTP/1.0 when authenticating to a proxy

### DIFF
--- a/rclient.go
+++ b/rclient.go
@@ -163,7 +163,8 @@ func connectviaproxy(proxyaddr string, connectaddr string) net.Conn {
 		//disable socket read timeouts
 		conn.SetReadDeadline(time.Now().Add(100 * time.Hour))
 
-		if strings.Contains(status, "HTTP/1.1 200 ") {
+		if (strings.Contains(status, "HTTP/1.1 200 ")) ||
+		(strings.Contains(status, "HTTP/1.0 200 ")) {
 			log.Print("Connected via proxy")
 			return conn
 		}


### PR DESCRIPTION
While the initial connection already accepts both HTTP/1.0 and HTTP/1.1 (https://github.com/kost/revsocks/blob/master/rclient.go#L77), if an auth is required only HTTP/1.1 response is accepted.

This PR fixes that.