### PR TITLE
[fix] Re-added user-supplied password

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,6 +96,7 @@ func main() {
 		log.Printf("No password specified. Generated password is %s", agentpassword)
 	} else {
 		agentpassword = CurOptions.agentpassword
+	}
 
 	if CurOptions.listen != "" {
 		log.Println("Starting to listen for clients")


### PR DESCRIPTION
User-supplied password wasn't used.

It was removed here: https://github.com/kost/revsocks/commit/80aeb3e19846e2bab3158c9eebd9c03ab6174c97